### PR TITLE
Making names shorter

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,7 +1,9 @@
 %{ if custom_values }
 ${custom_values_content}
 %{~ else ~}
+nameOverride: "nx"
 controller:
+  name: ic
   replicaCount: 1
 
   ingressClass: ${namespace}


### PR DESCRIPTION
When long namespaces names are supplied we see errors like:

```
Command: cd namespaces/live-1.cloud-platform.service.justice.gov.uk/manage-hmpps-auth-accounts-preprod/resources; terraform apply -auto-approve failed.
Error: Service "manage-hmpps-auth-accounts-preprod-nginx-ingress-controller-metrics" is invalid: metadata.name: Invalid value: "manage-hmpps-auth-accounts-preprod-nginx-ingress-controller-metrics": must be no more than 63 characters
  on .terraform/modules/ingress_controller/main.tf line 10, in resource "helm_release" "nginx":
  10: resource "helm_release" "nginx" {
```

This fixes the problem, it replaces `nginx-ingress-controller` with `nx-ic`