### PR TITLE
Add a status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cloud-platform-terraform-ingress-controller
 
+[![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-terraform-teams-ingress-controller/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller/releases)
+
 Terraform module used by teams to deploy nginx ingress controller in their namespaces
 
 ## Usage


### PR DESCRIPTION
All our other terraform module repos have a status badge as the 2nd line of their README.md

This brings this repo into line with the others.