### PR TITLE
ReplicaCount with a new variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ module "ingress_controller" {
 
 ## Inputs
 
-| Name       | Description                                                                        | Type   | Default | Required |
-|------------|------------------------------------------------------------------------------------|:------:|:-------:|:--------:|
-| namespace  | Namespace where ingress controller is going to be looking for ingresses            | string |    ""   |    yes   |
+| Name                   | Description                                                                        | Type   | Default | Required |
+|------------------------|------------------------------------------------------------------------------------|:------:|:-------:|:--------:|
+| namespace              | Namespace where ingress controller is going to be looking for ingresses            | string |    ""   |    yes   |
+| custom_values          | Set to true if you do not want to use the default values.yaml provided, fill custom_values_content variable with your custom values  | bool |    ""   |    yes   |
+| custom_values_content  | Provide `values.yaml` content for custom configuration                             | string |    ""   |    yes   |
+| default_cert           | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"  | string |    ""   |    yes   |
+| is_prod                | If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica | bool |  false   |  no   |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -21,5 +21,6 @@ resource "helm_release" "nginx" {
     custom_values         = var.custom_values
     custom_values_content = var.custom_values_content
     default_cert          = var.default_cert
+    replicaCount          = var.is_prod ? 2 : 1
   })]
 }

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -4,7 +4,7 @@ ${custom_values_content}
 nameOverride: "nx"
 controller:
   name: ic
-  replicaCount: 1
+  replicaCount: ${replicaCount}
 
   ingressClass: ${namespace}
   electionID: ingress-controller-leader-${namespace}

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "custom_values_content" {
 
 variable "default_cert" {
   type        = string
-  description = "This is particulary useful if you want your ingress controller to use a default TLS certificate, specify: namespace/secretName"
+  description = "Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"
   default     = ""
+}
+
+variable "is_prod" {
+  type        = bool
+  description = "If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica"
+  default     = false
 }


### PR DESCRIPTION
Using the variable `is_prod` we define the number of replicas nginx ingress controller will have:

- `is_prod = false` implies 1 replicas (default)
- `is_prod = true` implies 2 replicas
