### PR TITLE
Removed scoped 

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -8,9 +8,6 @@ controller:
 
   ingressClass: ${namespace}
   electionID: ingress-controller-leader-${namespace}
-  scope:
-    enabled: true
-    namespace: ${namespace}
 
   config:
     enable-modsecurity: "true"

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "custom_values_content" {
 variable "default_cert" {
   type        = string
   description = "Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"
-  default     = ""
+  default     = "ingress-controllers/default-certificate"
 }
 
 variable "is_production" {


### PR DESCRIPTION
In order to load the default certificate from the ingress-controller namespace, we need to remove the scope. 

Also it was set the default certificate to load as: ingress-controllers/default-certificate