### PR TITLE
Add static value to serviceMonitor configuration

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -78,7 +78,7 @@ controller:
     enabled: true
     serviceMonitor:
       enabled: true
-      namespace: ${namespace}
+      namespace: ingress-controllers
 
 %{ if default_cert != "" }
   extraArgs:


### PR DESCRIPTION
Allowing the namespace to be interpolated by the module call would
create a serviceMonitor resource in the users namespace. This is less
than ideal as the ingress-controller would live inside the
ingress-controllers namespace. This change ensures the serviceMonitor
lives in the same place as the ingress-controller resource.