### PR TITLE
Upgrade ingress-controller to 2.13.0,  using ingress-nginx chart

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,17 +2,17 @@
 # Helm #
 ########
 
-data "helm_repository" "stable" {
-  name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+data "helm_repository" "ingress-nginx" {
+  name = "ingress-nginx"
+  url  = "https://kubernetes.github.io/ingress-nginx"
 }
 
 resource "helm_release" "nginx" {
   # If we leave ingress-controller-${namespace} we get Error: Service "ingress-controller-starter-pack-nginx-ingress-controller-admission" is invalid: metadata.name: Invalid value: "ingress-controller-starter-pack-nginx-ingress-controller-admission": must be no more than 63 characters
   name       = var.namespace
-  chart      = "nginx-ingress"
-  repository = data.helm_repository.stable.metadata[0].name
-  version    = "1.35.0"
+  chart      = "ingress-nginx"
+  repository = data.helm_repository.ingress-nginx.metadata[0].name
+  version    = "2.13.0"
 
   namespace = "ingress-controllers"
 


### PR DESCRIPTION
Stable chart is deprecated
https://github.com/helm/charts/tree/master/stable/nginx-ingress#deprecated---nginx-ingress