### PR TITLE
Set dependency for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ module "ingress_controller" {
 | custom_values_content  | Provide `values.yaml` content for custom configuration                             | string |    ""   |    yes   |
 | default_cert           | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"  | string |    ""   |    yes   |
 | is_production          | If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica | bool |  false   |  no   |
-| dependence_prometheus  | When deployed cloud-platform-components monitoring nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus) | string | "NOTHING"  |  no   |
+| dependence_prometheus  | When deployed monitoring nginx ingress controller, if prometheus is not deployed before this module fails because it installs serviceMonitor (CRD from prometheus) | string | "NOTHING"  |  no   |
+| dependence_certmanager | When deployed monitoring nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate | string | "NOTHING"  |  no   |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "ingress_controller" {
 | custom_values_content  | Provide `values.yaml` content for custom configuration                             | string |    ""   |    yes   |
 | default_cert           | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"  | string |    ""   |    yes   |
 | is_production          | If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica | bool |  false   |  no   |
+| dependence_prometheus  | When deployed cloud-platform-components monitoring nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus) | string | "NOTHING"  |  no   |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -23,4 +23,9 @@ resource "helm_release" "nginx" {
     default_cert          = var.default_cert
     replicaCount          = var.is_production ? 2 : 1
   })]
+
+  depends_on = [
+    var.dependence_prometheus
+  ]
+
 }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,8 @@ resource "helm_release" "nginx" {
   })]
 
   depends_on = [
-    var.dependence_prometheus
+    var.dependence_prometheus,
+    var.dependence_certmanager
   ]
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "dependence_prometheus" {
   description = "When deployed cloud-platform-components monitoring nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus)"
   default     = "NOTHING"
 }
+
+variable "dependence_certmanager" {
+  type        = string
+  description = "When deployed monitoring nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate"
+  default     = "NOTHING"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,9 @@ variable "is_production" {
   description = "If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica"
   default     = false
 }
+
+variable "dependence_prometheus" {
+  type        = string
+  description = "When deployed cloud-platform-components monitoring nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus)"
+  default     = "NOTHING"
+}


### PR DESCRIPTION
Create and destroy clusters is currently failing. The reason behind this is: monitoring ingress controller doesn't get deployed due to ServiceMonitor CRD existence. ServiceMonitor CRD comes from Prometheus so I had to set a Prometheus dependence. 