### PR TITLE
Revert "Removed dependency variables, not required anymore"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ module "ingress_controller" {
 | custom_values_content  | Provide `values.yaml` content for custom configuration                             | string |    ""   |    yes   |
 | default_cert           | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"  | string |    ""   |    yes   |
 | is_production          | If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica | bool |  false   |  no   |
-| dependence_prometheus  | When deployed monitoring nginx ingress controller, if prometheus is not deployed before this module fails because it installs serviceMonitor (CRD from prometheus) | string | "NOTHING"  |  no   |
-| dependence_certmanager | When deployed monitoring nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate | string | "NOTHING"  |  no   |
+| dependence_prometheus  | When deployed integration_test nginx ingress controller, if prometheus is not deployed before this module fails because it installs serviceMonitor (CRD from prometheus) | string | "NOTHING"  |  no   |
+| dependence_certmanager | When deployed integration_test nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate | string | "NOTHING"  |  no   |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ module "ingress_controller" {
 | custom_values_content  | Provide `values.yaml` content for custom configuration                             | string |    ""   |    yes   |
 | default_cert           | Useful if you want to use a default certificate for your ingress controller. Format: namespace/secretName"  | string |    ""   |    yes   |
 | is_production          | If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica | bool |  false   |  no   |
+| dependence_prometheus  | When deployed monitoring nginx ingress controller, if prometheus is not deployed before this module fails because it installs serviceMonitor (CRD from prometheus) | string | "NOTHING"  |  no   |
+| dependence_certmanager | When deployed monitoring nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate | string | "NOTHING"  |  no   |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -23,4 +23,10 @@ resource "helm_release" "nginx" {
     default_cert          = var.default_cert
     replicaCount          = var.is_production ? 2 : 1
   })]
+
+  depends_on = [
+    var.dependence_prometheus,
+    var.dependence_certmanager
+  ]
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,15 @@ variable "is_production" {
   description = "If set to true: 2 ingress controller replicas are going to be deployed. Default: 1 replica"
   default     = false
 }
+
+variable "dependence_prometheus" {
+  type        = string
+  description = "When deployed cloud-platform-components monitoring nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus)"
+  default     = "NOTHING"
+}
+
+variable "dependence_certmanager" {
+  type        = string
+  description = "When deployed monitoring nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate"
+  default     = "NOTHING"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,12 +30,12 @@ variable "is_production" {
 
 variable "dependence_prometheus" {
   type        = string
-  description = "When deployed cloud-platform-components monitoring nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus)"
+  description = "When deployed cloud-platform-components integration_test nginx ingress controller, if prometheus is not deployed first it fails because it installs serviceMonitor (CRD from prometheus)"
   default     = "NOTHING"
 }
 
 variable "dependence_certmanager" {
   type        = string
-  description = "When deployed monitoring nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate"
+  description = "When deployed integration_test nginx ingress controller, if certmanager is not deployed before this module fails because it uses certmanager defaultCertificate"
   default     = "NOTHING"
 }


### PR DESCRIPTION
This reverts commit f1e468b.

We need this dependency for  "ingress_controller_integration_test"