### PR TITLE
Suppress `Server` header in http responses

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -11,6 +11,7 @@ controller:
 
   config:
     enable-modsecurity: "true"
+    server-tokens: "false"
     custom-http-errors: 413,502,503,504
     generate-request-id: "true"
     proxy-buffer-size: "16k"


### PR DESCRIPTION
This module is (currently) only used for the integration-test ingress controller.

So, this is a way to test https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/pull/8 without affecting the default or modsec ingress controllers.